### PR TITLE
[Feat] 응답에 error_code 및 status 코드 체계 도입

### DIFF
--- a/constants/errorCodes.js
+++ b/constants/errorCodes.js
@@ -1,0 +1,17 @@
+module.exports = {
+  // Dog-related errors (1000 ~ 1099)
+  DOG_CREATE_VALIDATION_FAILED: 1001,
+  DOG_CREATE_SERVER_FAILED: 1002,
+
+  DOG_FETCHED_FAILED: 1003,
+  DOG_UPDATE_FAILED: 1004,
+  DOG_DELETE_FAILED: 1005,
+
+  DOG_NOT_FOUND: 1006,
+  DOG_NOT_FOUND_FOR_UPDATE: 1007,
+  DOG_NOT_FOUND_FOR_DELETE: 1008,
+
+  // User-related errors (2000 ~ 2099)
+  // Question-related errors (3000 ~ 3099)
+  // Answer-related errors (4000 ~ 4099)
+};

--- a/constants/errorCodes.js
+++ b/constants/errorCodes.js
@@ -18,4 +18,8 @@ module.exports = {
 
   // Question-related errors (3000 ~ 3099)
   // Answer-related errors (4000 ~ 4099)
+
+  // Auth-related errors (5000 ~ 5099)
+  AUTH_KAKAO_UNAUTHORIZED: 5001,
+  AUTH_KAKAO_FAILED: 5002,
 };

--- a/constants/errorCodes.js
+++ b/constants/errorCodes.js
@@ -24,4 +24,5 @@ module.exports = {
   // Auth-related errors (5000 ~ 5099)
   AUTH_KAKAO_UNAUTHORIZED: 5001,
   AUTH_KAKAO_FAILED: 5002,
+  AUTH_UNAUTHORIZED: 5003,
 };

--- a/constants/errorCodes.js
+++ b/constants/errorCodes.js
@@ -17,6 +17,8 @@ module.exports = {
   USER_NOT_FOUND: 2003,
 
   // Question-related errors (3000 ~ 3099)
+  QUESTION_PROVIDE_FAILED: 3001,
+
   // Answer-related errors (4000 ~ 4099)
 
   // Auth-related errors (5000 ~ 5099)

--- a/constants/errorCodes.js
+++ b/constants/errorCodes.js
@@ -12,6 +12,10 @@ module.exports = {
   DOG_NOT_FOUND_FOR_DELETE: 1008,
 
   // User-related errors (2000 ~ 2099)
+  USER_FETCHED_FAILED: 2001,
+  USER_UPDATE_FAILED: 2002,
+  USER_NOT_FOUND: 2003,
+
   // Question-related errors (3000 ~ 3099)
   // Answer-related errors (4000 ~ 4099)
 };

--- a/constants/messages.js
+++ b/constants/messages.js
@@ -1,0 +1,20 @@
+module.exports = {
+  // 성공
+  DOG_CREATED: "강아지 등록 완료",
+  DOG_UPDATED: "강아지 수정 완료",
+  DOG_FETCHED: "강아지 조회 성공",
+
+  // 400
+  DOG_CREATE_VALIDATION_FAILED: "입력값이 올바르지 않습니다.",
+
+  // 404
+  DOG_NOT_FOUND: "등록된 강아지가 없습니다.",
+  DOG_NOT_FOUND_FOR_UPDATE: "수정할 강아지 정보가 없습니다.",
+  DOG_NOT_FOUND_FOR_DELETE: "삭제할 강아지 정보가 없습니다.",
+
+  // 500
+  DOG_CREATE_FAILED: "강아지 추가 중 예기치 않은 오류 발생",
+  DOG_FETCHED_FAILED: "강아지 정보 조회 중 예기치 않은 오류 발생",
+  DOG_UPDATE_FAILED: "강아지 수정 중 예기치 않은 오류 발생",
+  DOG_DELETE_FAILED: "강아지 삭제 중 예기치 않은 오류 발생",
+};

--- a/constants/messages.js
+++ b/constants/messages.js
@@ -1,4 +1,6 @@
 module.exports = {
+  // Dog
+
   // 성공
   DOG_CREATED: "강아지 등록 완료",
   DOG_UPDATED: "강아지 수정 완료",
@@ -17,4 +19,17 @@ module.exports = {
   DOG_FETCHED_FAILED: "강아지 정보 조회 중 예기치 않은 오류 발생",
   DOG_UPDATE_FAILED: "강아지 수정 중 예기치 않은 오류 발생",
   DOG_DELETE_FAILED: "강아지 삭제 중 예기치 않은 오류 발생",
+
+  // User
+
+  // 성공
+  USER_UPDATED: "프로필 수정 완료",
+  USER_FETCHED: "사용자 정보 조회 성공",
+
+  // 404
+  USER_NOT_FOUND: "사용자를 찾을 수 없습니다.",
+
+  // 500
+  USER_FETCHED_FAILED: "사용자 정보 조회 중 예기치 않은 오류 발생",
+  USER_UPDATE_FAILED: "프로필 수정 중 예기치 않은 오류 발생",
 };

--- a/constants/messages.js
+++ b/constants/messages.js
@@ -5,15 +5,12 @@ module.exports = {
   DOG_CREATED: "강아지 등록 완료",
   DOG_UPDATED: "강아지 수정 완료",
   DOG_FETCHED: "강아지 조회 성공",
-
   // 400
   DOG_CREATE_VALIDATION_FAILED: "입력값이 올바르지 않습니다.",
-
   // 404
   DOG_NOT_FOUND: "등록된 강아지가 없습니다.",
   DOG_NOT_FOUND_FOR_UPDATE: "수정할 강아지 정보가 없습니다.",
   DOG_NOT_FOUND_FOR_DELETE: "삭제할 강아지 정보가 없습니다.",
-
   // 500
   DOG_CREATE_FAILED: "강아지 추가 중 예기치 않은 오류 발생",
   DOG_FETCHED_FAILED: "강아지 정보 조회 중 예기치 않은 오류 발생",
@@ -25,11 +22,16 @@ module.exports = {
   // 성공
   USER_UPDATED: "프로필 수정 완료",
   USER_FETCHED: "사용자 정보 조회 성공",
-
   // 404
   USER_NOT_FOUND: "사용자를 찾을 수 없습니다.",
-
   // 500
   USER_FETCHED_FAILED: "사용자 정보 조회 중 예기치 않은 오류 발생",
   USER_UPDATE_FAILED: "프로필 수정 중 예기치 않은 오류 발생",
+
+  // Auth
+
+  // 401
+  AUTH_KAKAO_UNAUTHORIZED: "카카오 인증에 실패했습니다.",
+  // 500
+  AUTH_KAKAO_FAILED: "카카오 로그인 처리 중 예기치 않은 오류가 발생했습니다.",
 };

--- a/constants/messages.js
+++ b/constants/messages.js
@@ -36,8 +36,11 @@ module.exports = {
 
   // Auth
 
+  // 성공
+  AUTH_KAKAO_SUCCESS: "카카오 로그인 성공",
   // 401
   AUTH_KAKAO_UNAUTHORIZED: "카카오 인증에 실패했습니다.",
+  AUTH_UNAUTHORIZED: "인증되지 않은 사용자입니다.",
   // 500
   AUTH_KAKAO_FAILED: "카카오 로그인 처리 중 예기치 않은 오류가 발생했습니다.",
 };

--- a/constants/messages.js
+++ b/constants/messages.js
@@ -28,6 +28,12 @@ module.exports = {
   USER_FETCHED_FAILED: "사용자 정보 조회 중 예기치 않은 오류 발생",
   USER_UPDATE_FAILED: "프로필 수정 중 예기치 않은 오류 발생",
 
+  // Question
+
+  QUESTION_PROVIDE_FAILED: "질문 제공 중 예기치 않은 오류 발생",
+  QUESTION_PROVIDED: "질문 제공 성공",
+  ALL_QUESTIONS_ANSWERED: "모든 질문에 답변했습니다!",
+
   // Auth
 
   // 401

--- a/constants/statusCodes.js
+++ b/constants/statusCodes.js
@@ -1,0 +1,5 @@
+module.exports = {
+  SUCCESS: 0,
+  EMPTY: 1,
+  ERROR: 2,
+};

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,4 +1,5 @@
 const authService = require("../services/authService");
+const STATUS = require("../constants/statusCodes");
 const ERROR_CODES = require("../constants/errorCodes");
 const MESSAGES = require("../constants/messages");
 
@@ -6,18 +7,24 @@ const kakaoLogin = async (req, res) => {
   const { code } = req.body;
   try {
     const token = await authService.loginWithKakao(code);
-    res.json({ accessToken: token });
+    res.status(200).json({
+      status: STATUS.SUCCESS,
+      message: MESSAGES.AUTH_KAKAO_SUCCESS,
+      accessToken: token,
+    });
   } catch (err) {
     console.error("[AUTH] 카카오 로그인 실패", err.response?.data || err);
 
     if (err?.response?.status === 401) {
       return res.status(401).json({
+        status: STATUS.ERROR,
         error_code: ERROR_CODES.AUTH_KAKAO_UNAUTHORIZED,
         message: MESSAGES.AUTH_KAKAO_UNAUTHORIZED,
       });
     }
 
     res.status(500).json({
+      status: STATUS.ERROR,
       error_code: ERROR_CODES.AUTH_KAKAO_FAILED,
       message: MESSAGES.AUTH_KAKAO_FAILED,
     });

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,4 +1,6 @@
 const authService = require("../services/authService");
+const ERROR_CODES = require("../constants/errorCodes");
+const MESSAGES = require("../constants/messages");
 
 const kakaoLogin = async (req, res) => {
   const { code } = req.body;
@@ -6,8 +8,19 @@ const kakaoLogin = async (req, res) => {
     const token = await authService.loginWithKakao(code);
     res.json({ accessToken: token });
   } catch (err) {
-    console.error("카카오 로그인 실패", err.response?.data || err);
-    res.status(401).json({ message: "카카오 인증 실패" });
+    console.error("[AUTH] 카카오 로그인 실패", err.response?.data || err);
+
+    if (err?.response?.status === 401) {
+      return res.status(401).json({
+        error_code: ERROR_CODES.AUTH_KAKAO_UNAUTHORIZED,
+        message: MESSAGES.AUTH_KAKAO_UNAUTHORIZED,
+      });
+    }
+
+    res.status(500).json({
+      error_code: ERROR_CODES.AUTH_KAKAO_FAILED,
+      message: MESSAGES.AUTH_KAKAO_FAILED,
+    });
   }
 };
 

--- a/controllers/dogController.js
+++ b/controllers/dogController.js
@@ -1,5 +1,6 @@
 const dogService = require("../services/dogService");
 const formatToKST = require("../utils/formatDate");
+const STATUS = require("../constants/statusCodes");
 const ERROR_CODES = require("../constants/errorCodes");
 const MESSAGES = require("../constants/messages");
 
@@ -15,6 +16,7 @@ const addMyDog = async (req, res) => {
     };
 
     res.status(201).json({
+      status: STATUS.SUCCESS,
       message: MESSAGES.DOG_CREATED,
       dog: formattedDog,
     });
@@ -23,12 +25,14 @@ const addMyDog = async (req, res) => {
 
     if (error.name === "ValidationError") {
       return res.status(400).json({
+        status: STATUS.ERROR,
         error_code: ERROR_CODES.DOG_CREATE_VALIDATION_FAILED,
         message: MESSAGES.DOG_CREATE_VALIDATION_FAILED,
       });
     }
 
     return res.status(500).json({
+      status: STATUS.ERROR,
       error_code: ERROR_CODES.DOG_CREATE_SERVER_FAILED,
       message: MESSAGES.DOG_CREATE_FAILED,
     });
@@ -41,22 +45,28 @@ const getMyDogSummary = async (req, res) => {
 
     if (!dog) {
       return res.status(404).json({
+        status: STATUS.EMPTY,
         error_code: ERROR_CODES.DOG_NOT_FOUND,
         message: MESSAGES.DOG_NOT_FOUND,
       });
     }
 
+    const { _id, name, photo, togetherFor } = dog;
+
     res.status(200).json({
+      status: STATUS.SUCCESS,
       message: MESSAGES.DOG_FETCHED,
       dog: {
-        name: dog.name,
-        photo: dog.photo,
-        togetherFor: dog.togetherFor,
+        id: _id,
+        name,
+        photo,
+        togetherFor,
       },
     });
   } catch (error) {
     console.error("[DOG] 간단 조회 실패:", error);
     res.status(500).json({
+      status: STATUS.ERROR,
       error_code: ERROR_CODES.DOG_FETCHED_FAILED,
       message: MESSAGES.DOG_FETCHED_FAILED,
     });
@@ -69,6 +79,7 @@ const getMyDogDetail = async (req, res) => {
 
     if (!dog) {
       return res.status(404).json({
+        status: STATUS.EMPTY,
         error_code: ERROR_CODES.DOG_NOT_FOUND,
         message: MESSAGES.DOG_NOT_FOUND,
       });
@@ -81,12 +92,14 @@ const getMyDogDetail = async (req, res) => {
     };
 
     res.status(200).json({
+      status: STATUS.SUCCESS,
       message: MESSAGES.DOG_FETCHED,
       dog: formattedDog,
     });
   } catch (error) {
     console.error("[DOG] 상세 조회 실패:", error);
     res.status(500).json({
+      status: STATUS.ERROR,
       error_code: ERROR_CODES.DOG_FETCHED_FAILED,
       message: MESSAGES.DOG_FETCHED_FAILED,
     });
@@ -99,6 +112,7 @@ const updateMyDog = async (req, res) => {
 
     if (!updatedDog) {
       return res.status(404).json({
+        status: STATUS.EMPTY,
         error_code: ERROR_CODES.DOG_NOT_FOUND_FOR_UPDATE,
         message: MESSAGES.DOG_NOT_FOUND_FOR_UPDATE,
       });
@@ -113,12 +127,14 @@ const updateMyDog = async (req, res) => {
     };
 
     res.status(200).json({
+      status: STATUS.SUCCESS,
       message: MESSAGES.DOG_UPDATED,
       dog: formattedDog,
     });
   } catch (error) {
     console.error("[DOG] 수정 실패:", error);
     res.status(500).json({
+      status: STATUS.ERROR,
       error_code: ERROR_CODES.DOG_UPDATE_FAILED,
       message: MESSAGES.DOG_UPDATE_FAILED,
     });
@@ -131,6 +147,7 @@ const deleteMyDog = async (req, res) => {
 
     if (!result) {
       return res.status(404).json({
+        status: STATUS.EMPTY,
         error_code: ERROR_CODES.DOG_NOT_FOUND_FOR_DELETE,
         message: MESSAGES.DOG_NOT_FOUND_FOR_DELETE,
       });
@@ -140,6 +157,7 @@ const deleteMyDog = async (req, res) => {
   } catch (error) {
     console.error("[DOG] 삭제 실패:", error);
     res.status(500).json({
+      status: STATUS.ERROR,
       error_code: ERROR_CODES.DOG_DELETE_FAILED,
       message: MESSAGES.DOG_DELETE_FAILED,
     });

--- a/controllers/questionController.js
+++ b/controllers/questionController.js
@@ -1,23 +1,38 @@
 const questionService = require("../services/questionService");
+const STATUS = require("../constants/statusCodes");
+const ERROR_CODES = require("../constants/errorCodes");
+const MESSAGES = require("../constants/messages");
 
 const getUnansweredQuestion = async (req, res) => {
   try {
-    const userId = req.user._id;
-    const question = await questionService.getUnansweredQuestion(userId);
+    const question = await questionService.getUnansweredQuestion(req.user._id);
 
     if (!question) {
-      return res.status(200).json({ message: "모든 질문에 답변했습니다!" });
+      return res.status(200).json({
+        status: STATUS.EMPTY,
+        message: MESSAGES.ALL_QUESTIONS_ANSWERED,
+      });
     }
 
+    const { _id, text, createdAt, updatedAt } = question;
+
     res.status(200).json({
-      _id: question._id,
-      text: question.text,
-      createdAt: question.createdAt,
-      updatedAt: question.updatedAt,
+      status: STATUS.SUCCESS,
+      message: MESSAGES.QUESTION_PROVIDED,
+      question: {
+        id: _id,
+        text,
+        createdAt,
+        updatedAt,
+      },
     });
   } catch (error) {
-    console.error("질문 제공 실패:", error);
-    res.status(500).json({ message: "질문 제공 중 예기치 않은 오류 발생" });
+    console.error("[QUESTION] 질문 제공 실패:", error);
+    res.status(500).json({
+      status: STATUS.ERROR,
+      error_code: ERROR_CODES.QUESTION_PROVIDE_FAILED,
+      message: MESSAGES.QUESTION_PROVIDE_FAILED,
+    });
   }
 };
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,14 +1,17 @@
 const userService = require("../services/userService");
+const STATUS = require("../constants/statusCodes");
 const ERROR_CODES = require("../constants/errorCodes");
 const MESSAGES = require("../constants/messages");
 
 const getUserSummary = async (req, res) => {
   try {
-    const user = req.user;
+    const user = req.user; // passport-jwt로 인증된 사용자
 
     res.status(200).json({
+      status: STATUS.SUCCESS,
       message: MESSAGES.USER_FETCHED,
       user: {
+        id: user._id,
         nickName: user.nickName,
         profileImage: user.profileImage,
       },
@@ -16,6 +19,7 @@ const getUserSummary = async (req, res) => {
   } catch (error) {
     console.error("[USER] 간단 조회 실패:", error);
     res.status(500).json({
+      status: STATUS.ERROR,
       error_code: ERROR_CODES.USER_FETCHED_FAILED,
       message: MESSAGES.USER_FETCHED_FAILED,
     });
@@ -24,11 +28,13 @@ const getUserSummary = async (req, res) => {
 
 const getUserDetail = async (req, res) => {
   try {
-    const user = req.user; // passport-jwt로 인증된 사용자
+    const user = req.user;
 
     res.status(200).json({
+      status: STATUS.SUCCESS,
       message: MESSAGES.USER_FETCHED,
       user: {
+        id: user._id,
         email: user.email,
         nickName: user.nickName,
         profileImage: user.profileImage,
@@ -37,6 +43,7 @@ const getUserDetail = async (req, res) => {
   } catch (error) {
     console.error("[USER] 상세 조회 실패:", error);
     res.status(500).json({
+      status: STATUS.ERROR,
       error_code: ERROR_CODES.USER_FETCHED_FAILED,
       message: MESSAGES.USER_FETCHED_FAILED,
     });
@@ -49,14 +56,17 @@ const updateUser = async (req, res) => {
 
     if (!updatedUser) {
       return res.status(404).json({
+        status: STATUS.EMPTY,
         error_code: ERROR_CODES.USER_NOT_FOUND,
         message: MESSAGES.USER_NOT_FOUND,
       });
     }
 
     res.status(200).json({
+      status: STATUS.SUCCESS,
       message: MESSAGES.USER_UPDATED,
       user: {
+        id: updatedUser._id,
         email: updatedUser.email,
         nickName: updatedUser.nickName,
         profileImage: updatedUser.profileImage,
@@ -65,6 +75,7 @@ const updateUser = async (req, res) => {
   } catch (error) {
     console.error("[USER] 수정 실패:", error);
     res.status(500).json({
+      status: STATUS.ERROR,
       error_code: ERROR_CODES.USER_UPDATE_FAILED,
       message: MESSAGES.USER_UPDATE_FAILED,
     });

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,15 +1,24 @@
 const userService = require("../services/userService");
+const ERROR_CODES = require("../constants/errorCodes");
+const MESSAGES = require("../constants/messages");
 
 const getUserSummary = async (req, res) => {
   try {
     const user = req.user;
+
     res.status(200).json({
-      nickName: user.nickName,
-      profileImage: user.profileImage,
+      message: MESSAGES.USER_FETCHED,
+      user: {
+        nickName: user.nickName,
+        profileImage: user.profileImage,
+      },
     });
   } catch (error) {
-    console.error("사용자 간단 조회 실패:", error);
-    res.status(500).json({ message: "사용자 정보 조회 중 예기치 않은 오류 발생" });
+    console.error("[USER] 간단 조회 실패:", error);
+    res.status(500).json({
+      error_code: ERROR_CODES.USER_FETCHED_FAILED,
+      message: MESSAGES.USER_FETCHED_FAILED,
+    });
   }
 };
 
@@ -18,27 +27,35 @@ const getUserDetail = async (req, res) => {
     const user = req.user; // passport-jwt로 인증된 사용자
 
     res.status(200).json({
-      email: user.email,
-      nickName: user.nickName,
-      profileImage: user.profileImage,
+      message: MESSAGES.USER_FETCHED,
+      user: {
+        email: user.email,
+        nickName: user.nickName,
+        profileImage: user.profileImage,
+      },
     });
   } catch (error) {
-    console.error("프로필 조회 실패:", error);
-    res.status(500).json({ message: "프로필 조회 중 예기치 않은 오류 발생" });
+    console.error("[USER] 상세 조회 실패:", error);
+    res.status(500).json({
+      error_code: ERROR_CODES.USER_FETCHED_FAILED,
+      message: MESSAGES.USER_FETCHED_FAILED,
+    });
   }
 };
 
 const updateUser = async (req, res) => {
   try {
-    const userId = req.user._id;
-    const updatedUser = await userService.updateProfile(userId, req.body);
+    const updatedUser = await userService.updateProfile(req.user._id, req.body);
 
     if (!updatedUser) {
-      return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
+      return res.status(404).json({
+        error_code: ERROR_CODES.USER_NOT_FOUND,
+        message: MESSAGES.USER_NOT_FOUND,
+      });
     }
 
     res.status(200).json({
-      message: "프로필 수정 완료",
+      message: MESSAGES.USER_UPDATED,
       user: {
         email: updatedUser.email,
         nickName: updatedUser.nickName,
@@ -46,8 +63,11 @@ const updateUser = async (req, res) => {
       },
     });
   } catch (error) {
-    console.error("프로필 수정 실패:", error);
-    res.status(500).json({ message: "프로필 수정 중 오류 발생" });
+    console.error("[USER] 수정 실패:", error);
+    res.status(500).json({
+      error_code: ERROR_CODES.USER_UPDATE_FAILED,
+      message: MESSAGES.USER_UPDATE_FAILED,
+    });
   }
 };
 

--- a/database.js
+++ b/database.js
@@ -4,8 +4,6 @@ const connectDB = async () => {
   try {
     await mongoose.connect(process.env.DB_URL, {
       dbName: process.env.DB_NAME,
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
     });
     console.log("MongoDB 연결 성공");
   } catch (error) {

--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -1,5 +1,13 @@
 const passport = require("passport");
 
-const isAuthenticated = passport.authenticate("jwt", { session: false });
+const isAuthenticated = (req, res, next) => {
+  passport.authenticate("jwt", { session: false }, (err, user) => {
+    if (err || !user) {
+      return next({ name: "UnauthorizedError" });
+    }
+    req.user = user;
+    next();
+  })(req, res, next);
+};
 
 module.exports = { isAuthenticated };

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,0 +1,16 @@
+const STATUS = require("../constants/statusCodes");
+const ERROR_CODES = require("../constants/errorCodes");
+const MESSAGES = require("../constants/messages");
+
+const handleAuthError = (err, req, res, next) => {
+  if (err?.name === "UnauthorizedError") {
+    return res.status(401).json({
+      status: STATUS.ERROR,
+      error_code: ERROR_CODES.AUTH_UNAUTHORIZED,
+      message: MESSAGES.AUTH_UNAUTHORIZED,
+    });
+  }
+  next(err);
+};
+
+module.exports = { handleAuthError };

--- a/models/Question.js
+++ b/models/Question.js
@@ -4,7 +4,10 @@ const questionSchema = new mongoose.Schema(
   {
     text: { type: String, required: true },
   },
-  { timestamps: true, versionKey: false }
+  {
+    timestamps: true,
+    versionKey: false,
+  }
 );
 
 module.exports = mongoose.model("Question", questionSchema);

--- a/server.js
+++ b/server.js
@@ -10,6 +10,8 @@ const dogRouter = require("./routes/dogs");
 const userRouter = require("./routes/users");
 const questionRouter = require("./routes/questions");
 
+const { handleAuthError } = require("./middlewares/errorHandler");
+
 const app = express();
 connectDB();
 
@@ -31,6 +33,8 @@ app.use("/", authRouter);
 app.use("/dogs", dogRouter);
 app.use("/users/me", userRouter);
 app.use("/questions", questionRouter);
+
+app.use(handleAuthError);
 
 app.listen(process.env.PORT, () => {
   console.log(`${process.env.PORT} 포트에서 서버 실행 중`);


### PR DESCRIPTION
# 주요 변경 사항
## 1. 에러 코드 체계 도입
- 모든 기능의 실패 응답에 error_code 필드 추가
- 에러 코드는 constants/errorCodes.js 에 상수화
- 성공/실패 메시지는 constants/messages.js 로 상수화

## 2. 상태 코드 status 필드 추가
- 응답의 상태를 명확하게 구분하기 위한 필드 추가
```
0: SUCCESS
1: EMPTY (예: 응답할 데이터 없음)
2: ERROR (서버 오류, 실패 등)
```

## 3. 기능별 컨트롤러 리팩토링
- 강아지 관련 기능 (dogController)
  - 등록 / 상세 / 요약 / 수정 / 삭제 모두 status + error_code 통일 적용

- 사용자 관련 기능 (userController)
  - 요약 / 상세 / 수정 응답 포맷 통일 + 에러 코드 적용

- 인증 관련 기능 (authController)
  - 카카오 로그인 실패 시 에러 코드 및 상태 코드 반환

- 질문 기능 (questionController)
  - 미답변 질문 없을 경우 EMPTY 상태 반환
  - aggregate 사용으로 구조 분해 방식 적용하여 id 직접 추출

## 4. 공통 에러 핸들링 추가
- JWT 토큰 만료 등 인증 실패 시 handleAuthError 미들웨어에서 401 에러 처리
→ error_code: 5003, message: "인증되지 않은 사용자입니다."

## 5. MongoDB 연결 옵션 정리
- 더 이상 사용되지 않는 useNewUrlParser, useUnifiedTopology 옵션 제거

📌 관련 이슈
closes: [#17](https://github.com/mungBTI/dog-be/issues/17) 응답에 error_code 추가