### PR TITLE
[Feat] 사진 처리 방식 변경 (URL 기반 → ID 기반)

### DIFF
--- a/controllers/answerController.js
+++ b/controllers/answerController.js
@@ -18,7 +18,7 @@ const getTodayAnswer = async (req, res) => {
       answer: {
         id: answer.id,
         answerText: answer.answerText,
-        photos: answer.photos,
+        photoUrls: answer.photoUrls || [],
         isDraft: answer.isDraft,
       },
     });
@@ -37,9 +37,9 @@ const getTodayAnswer = async (req, res) => {
 
 const saveTodayAnswer = async (req, res) => {
   try {
-    const { answerText = "", photos = [] } = req.body;
+    const { answerText = "", photoIds = [] } = req.body;
 
-    const answer = await answerService.saveTodayAnswer(req.user._id, answerText, photos);
+    const answer = await answerService.saveTodayAnswer(req.user._id, answerText, photoIds);
 
     res.status(201).json({
       status: STATUS.SUCCESS,
@@ -183,16 +183,14 @@ const getAnswerDetailByAnswerId = async (req, res) => {
       });
     }
 
-    const formattedAnswer = {
-      ...answer.toJSON(),
-      createdAt: formatToKST(answer.createdAt),
-      updatedAt: formatToKST(answer.updatedAt),
-    };
-
     res.status(200).json({
       status: STATUS.SUCCESS,
       message: MESSAGES.ANSWER_FETCHED_DETAIL,
-      answer: formattedAnswer,
+      answer: {
+        ...answer,
+        createdAt: formatToKST(answer.createdAt),
+        updatedAt: formatToKST(answer.updatedAt),
+      },
     });
   } catch (error) {
     console.error("[ANSWER] 상세 조회 실패:", error);
@@ -225,7 +223,7 @@ const updateAnswer = async (req, res) => {
         status: STATUS.SUCCESS,
         message: MESSAGES.ANSWER_NO_UPDATE_FIELD,
         answer: {
-          ...answer.toJSON(),
+          ...answer,
           createdAt: formatToKST(answer.createdAt),
           updatedAt: formatToKST(answer.updatedAt),
         },

--- a/controllers/photoController.js
+++ b/controllers/photoController.js
@@ -43,8 +43,7 @@ const uploadAnswerPhotos = async (req, res) => {
       });
     }
 
-    const { answerId } = req.body;
-    const result = await answerPhotoService.uploadAnswerPhotos(req.files, answerId);
+    const result = await answerPhotoService.uploadAnswerPhotos(req.files);
 
     return res.status(201).json({
       status: STATUS.SUCCESS,

--- a/models/Answer.js
+++ b/models/Answer.js
@@ -11,7 +11,7 @@ const answerSchema = new mongoose.Schema(
         return !this.isDraft; // isDraft가 false일 때만 필수
       },
     },
-    photos: [{ type: String }],
+    photoIds: [{ type: mongoose.Schema.Types.ObjectId, ref: "AnswerPhoto" }],
     isDraft: { type: Boolean, default: true },
     dateKey: { type: String, required: true },
     isDeleted: { type: Boolean, default: false },

--- a/models/AnswerPhoto.js
+++ b/models/AnswerPhoto.js
@@ -2,7 +2,6 @@ const mongoose = require("mongoose");
 
 const answerPhotoSchema = new mongoose.Schema(
   {
-    answerId: { type: mongoose.Schema.Types.ObjectId, ref: "Answer", required: true },
     objectName: { type: String, required: true },
     uri: { type: String, required: true },
     parExpiresAt: { type: Date, required: true },

--- a/repositories/answerPhotoRepository.js
+++ b/repositories/answerPhotoRepository.js
@@ -1,28 +1,14 @@
 const AnswerPhoto = require("../models/AnswerPhoto");
 
-// 응답 이미지 도큐먼트 생성
-const createAnswerPhoto = async ({ answerId, objectName, uri, parExpiresAt }) => {
-  return await AnswerPhoto.create({ answerId, objectName, uri, parExpiresAt });
+const createAnswerPhoto = async ({ objectName, uri, parExpiresAt }) => {
+  return await AnswerPhoto.create({ objectName, uri, parExpiresAt });
 };
 
-// 특정 응답에 연결된 이미지 목록 조회
-const findPhotosByAnswerId = async (answerId) => {
-  return await AnswerPhoto.find({ answerId }).sort({ createdAt: 1 });
-};
-
-// 객체 이름으로 조회 (PAR 재발급 등)
-const findByObjectName = async (objectName) => {
-  return await AnswerPhoto.findOne({ objectName });
-};
-
-// 만료된 이미지 찾기
-const findExpiredPhotos = async () => {
-  return await AnswerPhoto.find({ parExpiresAt: { $lte: new Date() } });
+const findPhotoById = async (id) => {
+  return await AnswerPhoto.findById(id);
 };
 
 module.exports = {
   createAnswerPhoto,
-  findPhotosByAnswerId,
-  findByObjectName,
-  findExpiredPhotos,
+  findPhotoById,
 };

--- a/repositories/answerRepository.js
+++ b/repositories/answerRepository.js
@@ -30,7 +30,7 @@ const findAnswerDetailByAnswerId = async (userId, answerId) => {
     _id: answerId,
     userId,
     isDeleted: false,
-  });
+  }).populate("photoIds");
 };
 
 const updateAnswerByAnswerId = async (userId, answerId, updateData) => {
@@ -38,7 +38,7 @@ const updateAnswerByAnswerId = async (userId, answerId, updateData) => {
     { _id: answerId, userId, isDeleted: false },
     { $set: updateData },
     { new: true }
-  );
+  ).populate("photoIds");
 };
 
 const deleteAnswerByAnswerId = async (userId, answerId) => {
@@ -50,7 +50,7 @@ const deleteAnswerByAnswerId = async (userId, answerId) => {
 };
 
 const findTodayAnswer = async (userId, dateKey) => {
-  return await Answer.findOne({ userId, dateKey, isDeleted: false });
+  return await Answer.findOne({ userId, dateKey, isDeleted: false }).populate("photoIds");
 };
 
 const createAnswer = async ({
@@ -58,7 +58,7 @@ const createAnswer = async ({
   questionId,
   questionText,
   answerText,
-  photos,
+  photoIds,
   dateKey,
   isDraft,
 }) => {
@@ -67,24 +67,34 @@ const createAnswer = async ({
     questionId,
     questionText,
     answerText,
-    photos,
+    photoIds,
     dateKey,
     isDraft,
   });
 };
 
-const upsertTodayAnswer = async ({ userId, dateKey, answerText, photos, isDraft }) => {
+const upsertTodayAnswer = async ({ userId, dateKey, answerText, photoIds, isDraft }) => {
   return await Answer.findOneAndUpdate(
     { userId, dateKey },
     {
       $set: {
         answerText,
-        photos,
+        photoIds,
         isDraft,
       },
     },
     { new: true }
   );
+};
+
+const findTodayAnswerWithPhotoUrls = async (userId, dateKey) => {
+  const answer = await Answer.findOne({ userId, dateKey, isDeleted: false }).populate("photoIds");
+
+  if (!answer) return null;
+
+  const plain = answer.toJSON();
+  plain.photoUrls = answer.photoIds.map((photo) => photo.uri);
+  return plain;
 };
 
 module.exports = {
@@ -97,4 +107,5 @@ module.exports = {
   deleteAnswerByAnswerId,
   findTodayAnswer,
   upsertTodayAnswer,
+  findTodayAnswerWithPhotoUrls,
 };


### PR DESCRIPTION
- 응답 저장 시 photoUrl 대신 photoId 배열을 저장하도록 변경
- 응답 상세 조회 시 photoIds를 기반으로 PAR URL을 photoUrls로 반환
- 상세 조회 시 PAR URL 유효기간이 만료된 경우 자동으로 재발급되도록 처리
- 응답 수정 시 photoIds로 연결된 사진 정보 수정 가능하도록 처리
- AnswerPhoto 스키마에서 answerId 제거

관련: [Feature] 응답 저장, 조회, 수정에 이미지 관련 기능 반영 #38