### PR TITLE
[Feat] 유저, 강아지 프로필 이미지 필드 profilePhotoId로 구조 변경 및 상세 조회 시 PAR URL 반환

### DIFF
--- a/controllers/dogController.js
+++ b/controllers/dogController.js
@@ -1,4 +1,5 @@
 const dogService = require("../services/dogService");
+const profilePhotoService = require("../services/profilePhotoService");
 const formatToKST = require("../utils/formatDate");
 const STATUS = require("../constants/statusCodes");
 const ERROR_CODES = require("../constants/errorCodes");
@@ -51,15 +52,15 @@ const getMyDogSummary = async (req, res) => {
       });
     }
 
-    const { _id, name, photo, togetherFor } = dog;
+    const { id, name, profilePhotoUrl, togetherFor } = dog;
 
     res.status(200).json({
       status: STATUS.SUCCESS,
       message: MESSAGES.DOG_FETCHED,
       dog: {
-        id: _id,
+        id,
         name,
-        photo,
+        profilePhotoUrl,
         togetherFor,
       },
     });
@@ -85,10 +86,15 @@ const getMyDogDetail = async (req, res) => {
       });
     }
 
+    const dogObj = dog.toJSON();
+    dogObj.profilePhotoUrl = await profilePhotoService.getValidProfileParUrl(
+      dog.profilePhotoId?._id
+    );
+
     const formattedDog = {
-      ...dog.toJSON(),
-      birthday: formatToKST(dog.birthday),
-      firstMetAt: formatToKST(dog.firstMetAt),
+      ...dogObj,
+      birthday: formatToKST(dogObj.birthday),
+      firstMetAt: formatToKST(dogObj.firstMetAt),
     };
 
     res.status(200).json({

--- a/controllers/photoController.js
+++ b/controllers/photoController.js
@@ -15,12 +15,12 @@ const uploadProfilePhoto = async (req, res) => {
       });
     }
 
-    const parUrl = await profilePhotoService.uploadProfilePhoto(req.file, req.user._id);
+    const photoId = await profilePhotoService.uploadProfilePhoto(req.file, req.user._id);
 
     return res.status(201).json({
       status: STATUS.SUCCESS,
       message: MESSAGES.PHOTO_PROFILE_UPLOADED,
-      parUrl,
+      photoId: photoId,
     });
   } catch (error) {
     console.error("[PHOTO] 프로필 사진 업로드 실패:", error);

--- a/controllers/photoController.js
+++ b/controllers/photoController.js
@@ -15,12 +15,12 @@ const uploadProfilePhoto = async (req, res) => {
       });
     }
 
-    const parUrl = await profilePhotoService.uploadProfilePhoto(req.file, req.user._id);
+    const profilePhotoId = await profilePhotoService.uploadProfilePhoto(req.file, req.user._id);
 
     return res.status(201).json({
       status: STATUS.SUCCESS,
       message: MESSAGES.PHOTO_PROFILE_UPLOADED,
-      parUrl,
+      profilePhotoId: profilePhotoId,
     });
   } catch (error) {
     console.error("[PHOTO] 프로필 사진 업로드 실패:", error);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -5,7 +5,7 @@ const MESSAGES = require("../constants/messages");
 
 const getUserSummary = async (req, res) => {
   try {
-    const user = req.user; // passport-jwt로 인증된 사용자
+    const user = await userService.getUserWithProfilePhoto(req.user._id);
 
     res.status(200).json({
       status: STATUS.SUCCESS,
@@ -13,7 +13,7 @@ const getUserSummary = async (req, res) => {
       user: {
         id: user._id,
         nickName: user.nickName,
-        profileImage: user.profileImage,
+        profilePhotoUrl: user.profilePhotoUrl,
       },
     });
   } catch (error) {
@@ -28,7 +28,7 @@ const getUserSummary = async (req, res) => {
 
 const getUserDetail = async (req, res) => {
   try {
-    const user = req.user;
+    const user = await userService.getUserWithProfilePhoto(req.user._id);
 
     res.status(200).json({
       status: STATUS.SUCCESS,
@@ -37,7 +37,7 @@ const getUserDetail = async (req, res) => {
         id: user._id,
         email: user.email,
         nickName: user.nickName,
-        profileImage: user.profileImage,
+        profilePhotoUrl: user.profilePhotoUrl,
       },
     });
   } catch (error) {
@@ -62,14 +62,16 @@ const updateUser = async (req, res) => {
       });
     }
 
+    const userWithPhoto = await userService.getUserWithProfilePhoto(updatedUser._id);
+
     res.status(200).json({
       status: STATUS.SUCCESS,
       message: MESSAGES.USER_UPDATED,
       user: {
-        id: updatedUser._id,
-        email: updatedUser.email,
-        nickName: updatedUser.nickName,
-        profileImage: updatedUser.profileImage,
+        id: userWithPhoto._id,
+        email: userWithPhoto.email,
+        nickName: userWithPhoto.nickName,
+        profilePhotoUrl: userWithPhoto.profilePhotoUrl,
       },
     });
   } catch (error) {

--- a/models/Dog.js
+++ b/models/Dog.js
@@ -6,7 +6,7 @@ const dogSchema = new mongoose.Schema(
     name: { type: String, required: true },
     birthday: { type: Date, required: true },
     firstMetAt: { type: Date, required: true }, // 처음 만난 날
-    photo: { type: String },
+    profilePhotoId: { type: mongoose.Schema.Types.ObjectId, ref: "ProfilePhoto" },
   },
   {
     versionKey: false,

--- a/models/ProfilePhoto.js
+++ b/models/ProfilePhoto.js
@@ -2,10 +2,14 @@ const mongoose = require("mongoose");
 
 const profilePhotoSchema = new mongoose.Schema(
   {
-    userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
-    objectName: { type: String, required: true },
+    objectName: { type: String },
     uri: { type: String, required: true },
-    parExpiresAt: { type: Date, required: true },
+    parExpiresAt: { type: Date },
+    source: {
+      type: String,
+      enum: ["kakao", "internal"],
+      default: "internal",
+    },
   },
   {
     versionKey: false,

--- a/models/User.js
+++ b/models/User.js
@@ -5,8 +5,7 @@ const userSchema = new mongoose.Schema(
     kakaoId: { type: String, required: true, unique: true }, // 카카오 고유 ID
     email: { type: String },
     nickName: { type: String, required: true },
-    profileImage: { type: String },
-    createdAt: { type: Date, default: Date.now },
+    profilePhotoId: { type: mongoose.Schema.Types.ObjectId, ref: "ProfilePhoto" },
   },
   {
     timestamps: true,

--- a/repositories/profilePhotoRepository.js
+++ b/repositories/profilePhotoRepository.js
@@ -1,22 +1,27 @@
 const ProfilePhoto = require("../models/ProfilePhoto");
 
-// 프로필 사진 생성
-const createProfilePhoto = async ({ userId, objectName, uri, parExpiresAt }) => {
-  return await ProfilePhoto.create({ userId, objectName, uri, parExpiresAt });
+const createKakaoProfilePhoto = async (kakaoProfileUrl) => {
+  return await ProfilePhoto.create({
+    uri: kakaoProfileUrl,
+    source: "kakao",
+  });
 };
 
-// 사용자 ID로 최신 프로필 사진 조회
-const findLatestProfilePhotoByUserId = async (userId) => {
-  return await ProfilePhoto.findOne({ userId }).sort({ createdAt: -1 });
+const createInternalProfilePhoto = async ({ objectName, uri, parExpiresAt }) => {
+  return await ProfilePhoto.create({
+    objectName,
+    uri,
+    parExpiresAt,
+    source: "internal",
+  });
 };
 
-// 사용자 ID로 모든 프로필 사진 삭제 (교체 시)
-const deleteAllProfilePhotosByUserId = async (userId) => {
-  return await ProfilePhoto.deleteMany({ userId });
+const findPhotoById = async (photoId) => {
+  return await ProfilePhoto.findById(photoId);
 };
 
 module.exports = {
-  createProfilePhoto,
-  findLatestProfilePhotoByUserId,
-  deleteAllProfilePhotosByUserId,
+  createKakaoProfilePhoto,
+  createInternalProfilePhoto,
+  findPhotoById,
 };

--- a/repositories/userRepository.js
+++ b/repositories/userRepository.js
@@ -4,12 +4,27 @@ const findByKakaoId = (kakaoId) => {
   return User.findOne({ kakaoId });
 };
 
-const createUser = ({ kakaoId, email, nickName, profileImage }) => {
-  const newUser = new User({ kakaoId, email, nickName, profileImage });
+const findById = (userId) => {
+  return User.findById(userId);
+};
+
+const findByIdWithProfilePhoto = (userId) => {
+  return User.findById(userId).populate("profilePhotoId");
+};
+
+const createUser = ({ kakaoId, email, nickName, profilePhotoId }) => {
+  const newUser = new User({ kakaoId, email, nickName, profilePhotoId });
   return newUser.save();
+};
+
+const updateUserById = (userId, updateData) => {
+  return User.findByIdAndUpdate(userId, { $set: updateData }, { new: true });
 };
 
 module.exports = {
   findByKakaoId,
+  findById,
+  findByIdWithProfilePhoto,
   createUser,
+  updateUserById,
 };

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const userRepository = require("../repositories/userRepository");
+const profilePhotoRepository = require("../repositories/profilePhotoRepository");
 const { createToken } = require("../utils/jwt");
 
 const loginWithKakao = async (code) => {
@@ -25,17 +26,23 @@ const loginWithKakao = async (code) => {
   const { id, kakao_account, properties } = kakaoUser.data;
   const email = kakao_account.email;
   const nickName = properties.nickname;
-  const profileImage = properties.profile_image;
+  const kakaoProfileImageUrl = properties.profile_image;
 
   // 사용자 조회/생성
   let user = await userRepository.findByKakaoId(id);
   if (!user) {
-    user = await userRepository.createUser({ kakaoId: id, email, nickName, profileImage });
+    const profilePhoto = await profilePhotoRepository.createKakaoProfilePhoto(kakaoProfileImageUrl);
+
+    user = await userRepository.createUser({
+      kakaoId: id,
+      email,
+      nickName,
+      profilePhotoId: profilePhoto._id,
+    });
   }
 
   // JWT 발급
   const token = createToken({ userId: user._id });
-
   return token;
 };
 

--- a/services/dogService.js
+++ b/services/dogService.js
@@ -1,7 +1,8 @@
 const dogRepository = require("../repositories/dogRepository");
+const profilePhotoService = require("./profilePhotoService");
 
 const createDog = async (userId, dogData) => {
-  const { name, birthday, firstMetAt, photo } = dogData;
+  const { name, birthday, firstMetAt, profilePhotoId } = dogData;
 
   if (!name || !birthday || !firstMetAt) {
     throw new Error("이름, 생일, 만난 날짜는 모두 필수입니다.");
@@ -12,18 +13,27 @@ const createDog = async (userId, dogData) => {
     name,
     birthday,
     firstMetAt,
-    photo,
+    profilePhotoId,
   });
 
   return newDog;
 };
 
 const getDogByUserId = async (userId) => {
-  return await dogRepository.findDogByUserId(userId);
+  const dog = await dogRepository.findDogByUserId(userId);
+  if (!dog) return null;
+
+  dog.profilePhotoUrl = await profilePhotoService.getValidProfileParUrl(dog.profilePhotoId?._id);
+  return dog;
 };
 
 const updateDog = async (userId, updateData) => {
-  if (!updateData.name && !updateData.birthday && !updateData.firstMetAt && !updateData.photo) {
+  if (
+    !updateData.name &&
+    !updateData.birthday &&
+    !updateData.firstMetAt &&
+    !updateData.profilePhotoId
+  ) {
     throw new Error("수정할 필드를 최소 1개 이상 입력해주세요.");
   }
 

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,21 +1,32 @@
-const User = require("../models/User");
+const userRepository = require("../repositories/userRepository");
+const profilePhotoService = require("./profilePhotoService");
 
 const updateProfile = async (userId, updateData) => {
-  const { nickName, profileImage } = updateData;
+  const { nickName, profilePhotoId } = updateData;
 
-  if (!nickName && !profileImage) {
+  if (!nickName && !profilePhotoId) {
     throw new Error("수정할 필드를 최소 1개 이상 입력해주세요.");
   }
 
-  const updatedUser = await User.findByIdAndUpdate(
-    userId,
-    { $set: { nickName, profileImage } },
-    { new: true }
-  );
+  const updatePayload = {};
+  if (nickName) updatePayload.nickName = nickName;
+  if (profilePhotoId) updatePayload.profilePhotoId = profilePhotoId;
 
-  return updatedUser;
+  return await userRepository.updateUserById(userId, updatePayload);
 };
 
+const getUserWithProfilePhoto = async (userId) => {
+  const user = await userRepository.findByIdWithProfilePhoto(userId);
+  if (!user) return null;
+
+  const userObj = user.toJSON();
+  userObj.profilePhotoUrl = await profilePhotoService.getValidProfileParUrl(
+    user.profilePhotoId?._id
+  );
+
+  return userObj;
+};
 module.exports = {
   updateProfile,
+  getUserWithProfilePhoto,
 };


### PR DESCRIPTION
User
- User 모델에서 profileImage(string) → profilePhotoId(ObjectId)로 변경 
- 카카오 로그인 시 외부 URL을 ProfilePhoto 도큐먼트로 저장 후 참조 
- 사용자 등록/조회/수정 로직 전반에 profilePhotoId 기반으로 변경 
- profilePhotoId를 통해 PAR URL을 동적으로 생성해 반환 
- 기존 프로필 이미지 호스팅 parUrl → photoId 응답 형식으로 일관성 있게 수정

Dog
- Dog 스키마의 photo 필드를 profilePhotoId로 변경하여 ProfilePhoto 참조 방식 통일
- 강아지 등록/수정/조회 API에서 profilePhotoId 사용하도록 전체 서비스 및 컨트롤러 수정
- 상세 조회 시 profilePhotoId를 기반으로 PAR URL 동적 생성 및 profilePhotoUrl 필드로 응답

관련: [Feature] 유저, 강아지 프로필 이미지 관련 기능 수정 #41 