### PR TITLE
[Feat] HTTPS 인증서 적용, 도커 컨테이너 인증서 마운트 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,6 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
       - /home/ubuntu/.oci:/root/.oci:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     environment:
       - TZ=Asia/Seoul

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   app:
     build: .
     ports:
-      - "80:8443"
+      - "443:8443"
     env_file:
       - .env
     restart: always

--- a/server.js
+++ b/server.js
@@ -3,6 +3,8 @@ const express = require("express");
 const connectDB = require("./database.js");
 const passport = require("passport");
 const cors = require("cors");
+const https = require("https");
+const fs = require("fs");
 
 const jwtStrategy = require("./passport/jwtStrategy");
 const authRouter = require("./routes/auth");
@@ -40,6 +42,11 @@ app.use("/photos", photoRouter);
 
 app.use(handleAuthError);
 
-app.listen(process.env.PORT, () => {
-  console.log(`${process.env.PORT} 포트에서 서버 실행 중`);
+const credentials = {
+  key: fs.readFileSync(process.env.HTTPS_KEY_PATH),
+  cert: fs.readFileSync(process.env.HTTPS_CERT_PATH),
+};
+
+https.createServer(credentials, app).listen(process.env.PORT, () => {
+  console.log(`HTTPS 서버가 ${process.env.PORT} 포트에서 실행 중입니다.`);
 });


### PR DESCRIPTION
- server.js에서 https.createServer() 적용
- docker-compose.yml에서 443 포트 오픈 및 인증서 볼륨 마운트
- Let's Encrypt 인증서 디렉토리 마운트: /etc/letsencrypt:/etc/letsencrypt:ro

관련: [Feature] HTTPS 인증서 적용 및 포트 443 설정 #46 