### PR TITLE
[Feat] 응답 상세 조회 시 응답 순번 반환 구현

### DIFF
--- a/controllers/answerController.js
+++ b/controllers/answerController.js
@@ -188,6 +188,7 @@ const getAnswerDetailByAnswerId = async (req, res) => {
       message: MESSAGES.ANSWER_FETCHED_DETAIL,
       answer: {
         ...answer,
+        order: answer.order,
         createdAt: formatToKST(answer.createdAt),
         updatedAt: formatToKST(answer.updatedAt),
       },

--- a/repositories/answerRepository.js
+++ b/repositories/answerRepository.js
@@ -25,6 +25,15 @@ const findAnswerSummaryByAnswerId = async (userId, answerId) => {
   );
 };
 
+const countSubmittedAnswersExcludingDate = async (userId, dateKey) => {
+  return await Answer.countDocuments({
+    userId,
+    isDraft: false,
+    isDeleted: false,
+    dateKey: { $ne: dateKey },
+  });
+};
+
 const findAnswerDetailByAnswerId = async (userId, answerId) => {
   return await Answer.findOne({
     _id: answerId,
@@ -102,6 +111,7 @@ module.exports = {
   findAllAnswersByUserId,
   findAnswersByUserAndYearAndMonth,
   findAnswerSummaryByAnswerId,
+  countSubmittedAnswersExcludingDate,
   findAnswerDetailByAnswerId,
   updateAnswerByAnswerId,
   deleteAnswerByAnswerId,

--- a/services/answerService.js
+++ b/services/answerService.js
@@ -55,6 +55,11 @@ const getAnswerSummaryByAnswerId = async (userId, answerId) => {
   return await answerRepository.findAnswerSummaryByAnswerId(userId, answerId);
 };
 
+const getAnswerOrderForToday = async (userId, dateKey) => {
+  const count = await answerRepository.countSubmittedAnswersExcludingDate(userId, dateKey);
+  return count + 1;
+};
+
 const getAnswerDetailByAnswerId = async (userId, answerId) => {
   const answer = await answerRepository.findAnswerDetailByAnswerId(userId, answerId);
   if (!answer) return null;
@@ -64,6 +69,8 @@ const getAnswerDetailByAnswerId = async (userId, answerId) => {
     answer.photoIds.map((photoDoc) => answerPhotoService.getValidAnswerParUrl(photoDoc._id))
   );
   delete answerObj.photoIds;
+
+  answerObj.order = await getAnswerOrderForToday(userId, answer.dateKey);
 
   return answerObj;
 };


### PR DESCRIPTION
- 오늘 이전 제출된 답변 개수 + 1로 order(순번) 계산, 상세 조회 응답에 포함
- DB 저장 없이, 서비스 레이어에서 동적으로 계산 후 가상 필드로 반환
- 구조 변경 없이 기존 상세조회 API 응답에 order 필드 추가

관련: [Feature] 응답 회차 필드 추가 #47