### PR TITLE
[Feat] 오늘의 응답 및 상세 조회에 mood 필드 추가

### DIFF
--- a/constants/messages.js
+++ b/constants/messages.js
@@ -56,6 +56,7 @@ module.exports = {
   ANSWER_VALIDATION_FAILED: "필수 입력값이 누락되었습니다.",
   ANSWER_QUERY_VALIDATION_FAILED: "year 또는 month가 누락되었습니다.",
   ANSWER_NOT_FOUND: "해당 응답을 찾을 수 없습니다.",
+  ANSWER_MOOD_VALIDATION_FAILED: "기분 상태(mood) 값이 올바르지 않습니다.",
   // 500
   ANSWER_CREATE_FAILED: "응답 저장 중 예기치 않은 오류 발생",
   ANSWER_FETCH_ALL_FAILED: "응답 조회 중 예기치 않은 오류 발생",

--- a/constants/moodEnums.js
+++ b/constants/moodEnums.js
@@ -1,0 +1,3 @@
+module.exports = {
+  MOODS: ["EXCITED", "HAPPY", "ANGRY", "SAD", "NEUTRAL"],
+};

--- a/models/Answer.js
+++ b/models/Answer.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const { MOODS } = require("../constants/moodEnums");
 
 const answerSchema = new mongoose.Schema(
   {
@@ -15,6 +16,12 @@ const answerSchema = new mongoose.Schema(
     isDraft: { type: Boolean, default: true },
     dateKey: { type: String, required: true },
     isDeleted: { type: Boolean, default: false },
+    mood: {
+      type: String,
+      enum: MOODS,
+      default: null,
+      required: false,
+    },
   },
   {
     timestamps: true,

--- a/repositories/answerRepository.js
+++ b/repositories/answerRepository.js
@@ -46,7 +46,7 @@ const updateAnswerByAnswerId = async (userId, answerId, updateData) => {
   return await Answer.findOneAndUpdate(
     { _id: answerId, userId, isDeleted: false },
     { $set: updateData },
-    { new: true }
+    { new: true, runValidators: true }
   ).populate("photoIds");
 };
 
@@ -70,6 +70,7 @@ const createAnswer = async ({
   photoIds,
   dateKey,
   isDraft,
+  mood,
 }) => {
   return await Answer.create({
     userId,
@@ -79,20 +80,22 @@ const createAnswer = async ({
     photoIds,
     dateKey,
     isDraft,
+    mood,
   });
 };
 
-const upsertTodayAnswer = async ({ userId, dateKey, answerText, photoIds, isDraft }) => {
+const upsertTodayAnswer = async ({ userId, dateKey, answerText, photoIds, isDraft, mood }) => {
+  const updateFields = {
+    answerText,
+    photoIds,
+    isDraft,
+  };
+  if (mood !== undefined) updateFields.mood = mood;
+
   return await Answer.findOneAndUpdate(
     { userId, dateKey },
-    {
-      $set: {
-        answerText,
-        photoIds,
-        isDraft,
-      },
-    },
-    { new: true }
+    { $set: updateFields },
+    { new: true, runValidators: true }
   );
 };
 


### PR DESCRIPTION
- Answer 모델/서비스/컨트롤러에 mood(기분 상태, ENUM) 필드 반영
- mood 상수값을 ["EXCITED", "HAPPY", "ANGRY", "SAD", "NEUTRAL"]로 설정
- 응답 저장/수정 시 mood 입력값 저장 및 validation 추가
- 상세 조회, 오늘의 응답 조회 API 응답에  mood(기분 상태) 필드 포함
- 오늘의 응답 조회 API 응답에 order(n번째 답변 순번) 필드 포함
- mood 값 validation 에러 400 처리, 상세 메시지 분기

관련: [Feature] 응답 collection 기분 상태 필드 추가 #48